### PR TITLE
[#21] TypeHandler를 통해 Enum 타입으로 회원의 권한 분리 

### DIFF
--- a/src/main/java/com/flab/cafeguidebook/config/MyBatisConfig.java
+++ b/src/main/java/com/flab/cafeguidebook/config/MyBatisConfig.java
@@ -1,5 +1,7 @@
 package com.flab.cafeguidebook.config;
 
+import com.flab.cafeguidebook.enumeration.UserType;
+import com.flab.cafeguidebook.enumeration.UserType.TypeHandler;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import javax.sql.DataSource;
@@ -42,6 +44,9 @@ public class MyBatisConfig {
     sessionFactory.setDataSource(dataSource);
     sessionFactory
         .setMapperLocations(applicationContext.getResources("classpath:/mybatis/mapper/*.xml"));
+    sessionFactory.setTypeHandlers(new TypeHandler[]{
+        new UserType.TypeHandler()
+    });
     return sessionFactory.getObject();
   }
 

--- a/src/main/java/com/flab/cafeguidebook/controller/UserController.java
+++ b/src/main/java/com/flab/cafeguidebook/controller/UserController.java
@@ -3,6 +3,7 @@ package com.flab.cafeguidebook.controller;
 import com.flab.cafeguidebook.dto.UserDTO;
 import com.flab.cafeguidebook.exception.DuplicatedEmailException;
 import com.flab.cafeguidebook.service.UserService;
+import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,7 +30,7 @@ public class UserController {
 
   @PostMapping(value = "/signUp")
   @ResponseStatus(HttpStatus.CREATED)
-  public void signUp(@RequestBody UserDTO userDTO) {
+  public void signUp(@Valid @RequestBody UserDTO userDTO) {
     if (userService.isDuplicatedEmail(userDTO.getEmail())) {
       throw new DuplicatedEmailException();
     }

--- a/src/main/java/com/flab/cafeguidebook/enumeration/UserType.java
+++ b/src/main/java/com/flab/cafeguidebook/enumeration/UserType.java
@@ -17,7 +17,7 @@ public enum UserType {
   }
 
   @MappedTypes(UserType.class)
-  public static class TypeHandler extends UserTypeHandler<UserType> {
+  public static class TypeHandler extends UserTypeHandler {
 
     public TypeHandler() {
       super(UserType.class);

--- a/src/main/java/com/flab/cafeguidebook/enumeration/UserType.java
+++ b/src/main/java/com/flab/cafeguidebook/enumeration/UserType.java
@@ -1,5 +1,26 @@
 package com.flab.cafeguidebook.enumeration;
 
+import com.flab.cafeguidebook.enumeration.handler.UserTypeHandler;
+import org.apache.ibatis.type.MappedTypes;
+
 public enum UserType {
-  USER, OWNER, ADMIN
+  USER(0), OWNER(1), ADMIN(2);
+
+  private final int code;
+
+  UserType(int code) {
+    this.code = code;
+  }
+
+  public int getCode() {
+    return code;
+  }
+
+  @MappedTypes(UserType.class)
+  public static class TypeHandler extends UserTypeHandler<UserType> {
+
+    public TypeHandler() {
+      super(UserType.class);
+    }
+  }
 }

--- a/src/main/java/com/flab/cafeguidebook/enumeration/handler/UserTypeHandler.java
+++ b/src/main/java/com/flab/cafeguidebook/enumeration/handler/UserTypeHandler.java
@@ -9,11 +9,11 @@ import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeException;
 import org.apache.ibatis.type.TypeHandler;
 
-public class UserTypeHandler<E extends Enum<E>> implements TypeHandler<UserType> {
+public class UserTypeHandler implements TypeHandler<UserType> {
 
-  private Class<E> type;
+  private Class<UserType> type;
 
-  public UserTypeHandler(Class<E> type) {
+  public UserTypeHandler(Class<UserType> type) {
     this.type = type;
   }
 

--- a/src/main/java/com/flab/cafeguidebook/enumeration/handler/UserTypeHandler.java
+++ b/src/main/java/com/flab/cafeguidebook/enumeration/handler/UserTypeHandler.java
@@ -1,0 +1,58 @@
+package com.flab.cafeguidebook.enumeration.handler;
+
+import com.flab.cafeguidebook.enumeration.UserType;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.TypeException;
+import org.apache.ibatis.type.TypeHandler;
+
+public class UserTypeHandler<E extends Enum<E>> implements TypeHandler<UserType> {
+
+  private Class<E> type;
+
+  public UserTypeHandler(Class<E> type) {
+    this.type = type;
+  }
+
+  public void setParameter(PreparedStatement preparedStatement, int i, UserType type,
+      JdbcType jdbcType) throws
+      SQLException {
+    preparedStatement.setInt(i, type.getCode());
+  }
+
+  @Override
+  public UserType getResult(ResultSet resultSet, String s) throws SQLException {
+    int statusCode = resultSet.getInt(s);
+    return getStatus(statusCode);
+  }
+
+  @Override
+  public UserType getResult(ResultSet resultSet, int i) throws SQLException {
+    int statusCode = resultSet.getInt(i);
+    return getStatus(statusCode);
+  }
+
+  @Override
+  public UserType getResult(CallableStatement callableStatement, int i) throws SQLException {
+    int statusCode = callableStatement.getInt(i);
+    return getStatus(statusCode);
+  }
+
+  private UserType getStatus(int statusCode) {
+    try {
+      UserType[] enumConstants = (UserType[]) type.getEnumConstants();
+      for (UserType status : enumConstants) {
+        if (status.getCode() == statusCode) {
+          return status;
+        }
+      }
+      return null;
+    } catch (Exception exception) {
+      throw new TypeException("Can't make enum object '" + type + "'", exception);
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes #21
Fixes #49

## 개요

### 문제점
- 회원에 대한 권한이 분리되어 있지 않습니다.
- > `USER` : 일반사용자
- > `OWNER` : 카페사장
- > `ADMIN` : 어드민
- `MyBatis` 환경에서  `Enum` 타입을 `Int` 타입으로 변환해서 insert 하는 작업에 대해 핸들링 되지 않고 있습니다.
 
### 기대 효과
- 회원의 권한을 분리하여 앞으로 구현할 기능에 대비가 가능합니다.
- `MyBatis` 환경에서 `Enum`, `Int` 상호 변환을 자동으로 핸들링 해주는 `TypeHandler`를 적용하여 자바 소스코드에서 `Enum`을 사용할 수 있어 코드 가독성이 증진됩니다.

## 작업사항
- [x] 1. 회원 권한별 `Enum` 타입 선언
- [x] 2. `UserType` 전용 `TypeHandler` 구현 및 `SqlSessionFactory`에 추가
- [x] 3. 회원가입 비지니스 로직에 권한 분리 적용