### PR TITLE
[#30] 어드민 신규 Cafe에 대한 승인 및 반려 기능 구현

### DIFF
--- a/src/main/java/com/flab/cafeguidebook/controller/CafeController.java
+++ b/src/main/java/com/flab/cafeguidebook/controller/CafeController.java
@@ -10,6 +10,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -39,5 +41,15 @@ public class CafeController {
     }
     cafeService.addCafe(cafeDTO);
     return ResponseEntity.ok(cafeDTO);
+  }
+
+  @PatchMapping("/registeration/approve/{cafeId}/")
+  public void resolveRegistration(@PathVariable Long cafeId) {
+    cafeService.approveRegistration(cafeId);
+  }
+
+  @PatchMapping("/registeration/deny/{cafeId}")
+  public void denyRegistration(@PathVariable Long cafeId) {
+    cafeService.denyRegistration(cafeId);
   }
 }

--- a/src/main/java/com/flab/cafeguidebook/enumeration/CafeRegistration.java
+++ b/src/main/java/com/flab/cafeguidebook/enumeration/CafeRegistration.java
@@ -1,5 +1,26 @@
 package com.flab.cafeguidebook.enumeration;
 
+import com.flab.cafeguidebook.enumeration.handler.CafeRegistrationTypeHandler;
+import org.apache.ibatis.type.MappedTypes;
+
 public enum CafeRegistration {
-  PENDING, DENY, APPROVAL
+  PENDING(0), DENY(1), APPROVAL(2);
+
+  private final int code;
+
+  CafeRegistration(int code) {
+    this.code = code;
+  }
+
+  public int getCode() {
+    return code;
+  }
+
+  @MappedTypes(CafeRegistration.class)
+  public static class TypeHandler extends CafeRegistrationTypeHandler {
+
+    public TypeHandler() {
+      super(CafeRegistration.class);
+    }
+  }
 }

--- a/src/main/java/com/flab/cafeguidebook/enumeration/handler/CafeRegistrationTypeHandler.java
+++ b/src/main/java/com/flab/cafeguidebook/enumeration/handler/CafeRegistrationTypeHandler.java
@@ -1,0 +1,58 @@
+package com.flab.cafeguidebook.enumeration.handler;
+
+import com.flab.cafeguidebook.enumeration.CafeRegistration;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.TypeException;
+import org.apache.ibatis.type.TypeHandler;
+
+public class CafeRegistrationTypeHandler implements TypeHandler<CafeRegistration> {
+
+  private Class<CafeRegistration> type;
+
+  public CafeRegistrationTypeHandler(Class<CafeRegistration> type) {
+    this.type = type;
+  }
+
+  public void setParameter(PreparedStatement preparedStatement, int i, CafeRegistration type,
+      JdbcType jdbcType) throws
+      SQLException {
+    preparedStatement.setInt(i, type.getCode());
+  }
+
+  @Override
+  public CafeRegistration getResult(ResultSet resultSet, String s) throws SQLException {
+    int statusCode = resultSet.getInt(s);
+    return getStatus(statusCode);
+  }
+
+  @Override
+  public CafeRegistration getResult(ResultSet resultSet, int i) throws SQLException {
+    int statusCode = resultSet.getInt(i);
+    return getStatus(statusCode);
+  }
+
+  @Override
+  public CafeRegistration getResult(CallableStatement callableStatement, int i)
+      throws SQLException {
+    int statusCode = callableStatement.getInt(i);
+    return getStatus(statusCode);
+  }
+
+  private CafeRegistration getStatus(int statusCode) {
+    try {
+      CafeRegistration[] enumConstants = (CafeRegistration[]) type.getEnumConstants();
+      for (CafeRegistration status : enumConstants) {
+        if (status.getCode() == statusCode) {
+          return status;
+        }
+      }
+      return null;
+    } catch (Exception exception) {
+      throw new TypeException("Can't make enum object '" + type + "'", exception);
+    }
+  }
+}

--- a/src/main/java/com/flab/cafeguidebook/mapper/CafeMapper.java
+++ b/src/main/java/com/flab/cafeguidebook/mapper/CafeMapper.java
@@ -1,10 +1,15 @@
 package com.flab.cafeguidebook.mapper;
 
 import com.flab.cafeguidebook.dto.CafeDTO;
+import com.flab.cafeguidebook.enumeration.CafeRegistration;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface CafeMapper {
 
   public int insertCafe(CafeDTO cafeDTO);
+
+  public int updateRegistration(@Param("id") Long id,
+      @Param("registration") CafeRegistration registration);
 }

--- a/src/main/java/com/flab/cafeguidebook/service/CafeService.java
+++ b/src/main/java/com/flab/cafeguidebook/service/CafeService.java
@@ -1,6 +1,7 @@
 package com.flab.cafeguidebook.service;
 
 import com.flab.cafeguidebook.dto.CafeDTO;
+import com.flab.cafeguidebook.enumeration.CafeRegistration;
 import com.flab.cafeguidebook.mapper.CafeMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -14,5 +15,13 @@ public class CafeService {
   public boolean addCafe(CafeDTO cafeDTO) {
     int insertCafe = cafeMapper.insertCafe(cafeDTO);
     return insertCafe == 1;
+  }
+
+  public boolean approveRegistration(Long cafeId) {
+    return cafeMapper.updateRegistration(cafeId, CafeRegistration.APPROVAL) == 1;
+  }
+
+  public boolean denyRegistration(Long cafeId) {
+    return cafeMapper.updateRegistration(cafeId, CafeRegistration.DENY) == 1;
   }
 }

--- a/src/main/resources/mybatis/mapper/CafeMapper.xml
+++ b/src/main/resources/mybatis/mapper/CafeMapper.xml
@@ -40,5 +40,10 @@
             #{cafeCondition},
             #{cafeRegistration})
   </insert>
+
+  <update id="updateRegistration">
+        UPDATE CAFE SET registration = #{registration}
+        WHERE id = #{id}
+    </update>
 </mapper>
 

--- a/src/test/java/com/flab/cafeguidebook/service/CafeServiceTest.java
+++ b/src/test/java/com/flab/cafeguidebook/service/CafeServiceTest.java
@@ -1,5 +1,7 @@
 package com.flab.cafeguidebook.service;
 
+import static com.flab.cafeguidebook.enumeration.CafeRegistration.APPROVAL;
+import static com.flab.cafeguidebook.enumeration.CafeRegistration.DENY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
@@ -27,5 +29,21 @@ public class CafeServiceTest {
   public void addCafe(CafeDTO testCafeDTO) {
     given(cafeMapper.insertCafe(testCafeDTO)).willReturn(1);
     assertThat(cafeService.addCafe(testCafeDTO)).isEqualTo(true);
+  }
+
+  @Test
+  public void approveRegistrationCafeSuccess() {
+    given(cafeMapper.updateRegistration(33333L, APPROVAL))
+        .willReturn(1);
+
+    assertThat(cafeService.approveRegistration(33333L)).isEqualTo(true);
+  }
+
+  @Test
+  public void denyRegistrationCafeSuccess() {
+    given(cafeMapper.updateRegistration(33333L, DENY))
+        .willReturn(1);
+
+    assertThat(cafeService.denyRegistration(33333L)).isEqualTo(true);
   }
 }


### PR DESCRIPTION
Fixes #30 

## 개요


- 어드민이 신규 카페에 대한 승인 및 반려 기능을 구현합니다.
- 카페의 등록 상태를 정의한 `CafeRegistration` 열거형 타입 (`PENDING`, `DENY`, `APPROVAL`) 를 MyBatis에서 다루기 위해 TypeHandler를 적용합니다
## 작업사항


- [x] 1. `CafeRegistration` 열거형 타입에 대한 TypeHandler 적용
- [x] 2. 승인 및 반려에 대한 `Service`, `Controller` 메서드 구현
- [x] 3. 단위 테스트 추가