### PR TITLE
[#86] TypeHandler를 통해 Enum 타입 처리(MenuGroup, MenuStatus, OptionStatus, CafeCondition, CafeRegistration) 

### DIFF
--- a/src/main/java/com/flab/cafeguidebook/config/MyBatisConfig.java
+++ b/src/main/java/com/flab/cafeguidebook/config/MyBatisConfig.java
@@ -1,11 +1,16 @@
 package com.flab.cafeguidebook.config;
 
+import com.flab.cafeguidebook.enumeration.CafeCondition;
+import com.flab.cafeguidebook.enumeration.CafeRegistration;
+import com.flab.cafeguidebook.enumeration.MenuGroup;
+import com.flab.cafeguidebook.enumeration.MenuStatus;
+import com.flab.cafeguidebook.enumeration.OptionStatus;
 import com.flab.cafeguidebook.enumeration.UserType;
-import com.flab.cafeguidebook.enumeration.UserType.TypeHandler;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import javax.sql.DataSource;
 import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.type.TypeHandler;
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.SqlSessionTemplate;
 import org.mybatis.spring.annotation.MapperScan;
@@ -42,10 +47,16 @@ public class MyBatisConfig {
   public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
     final SqlSessionFactoryBean sessionFactory = new SqlSessionFactoryBean();
     sessionFactory.setDataSource(dataSource);
+    sessionFactory.setConfigLocation(applicationContext.getResource("classpath:/mybatis/config/mybatis-config.xml"));
     sessionFactory
         .setMapperLocations(applicationContext.getResources("classpath:/mybatis/mapper/*.xml"));
     sessionFactory.setTypeHandlers(new TypeHandler[]{
-        new UserType.TypeHandler()
+        new UserType.TypeHandler(),
+        new CafeCondition.TypeHandler(),
+        new CafeRegistration.TypeHandler(),
+        new MenuGroup.TypeHandler(),
+        new MenuStatus.TypeHandler(),
+        new OptionStatus.TypeHandler()
     });
     return sessionFactory.getObject();
   }

--- a/src/main/java/com/flab/cafeguidebook/domain/Cafe.java
+++ b/src/main/java/com/flab/cafeguidebook/domain/Cafe.java
@@ -270,12 +270,12 @@ public class Cafe {
       return this;
     }
 
-    public Cafe.Builder userId(@NonNull final Long userId) {
+    public Cafe.Builder userId(final Long userId) {
       this.userId = userId;
       return this;
     }
 
-    public Cafe.Builder cafeId(@NonNull final Long cafeId) {
+    public Cafe.Builder cafeId(final Long cafeId) {
       this.cafeId = cafeId;
       return this;
     }

--- a/src/main/java/com/flab/cafeguidebook/enumeration/CafeCondition.java
+++ b/src/main/java/com/flab/cafeguidebook/enumeration/CafeCondition.java
@@ -1,5 +1,26 @@
 package com.flab.cafeguidebook.enumeration;
 
+import com.flab.cafeguidebook.enumeration.handler.CafeConditionTypeHandler;
+import org.apache.ibatis.type.MappedTypes;
+
 public enum CafeCondition {
-  OPEN, CLOSE
+  OPEN(0), CLOSE(1);
+
+  private final int code;
+
+  CafeCondition(int code) {
+    this.code = code;
+  }
+
+  public int getCode() {
+    return code;
+  }
+
+  @MappedTypes(CafeCondition.class)
+  public static class TypeHandler extends CafeConditionTypeHandler {
+
+    public TypeHandler() {
+      super(CafeCondition.class);
+    }
+  }
 }

--- a/src/main/java/com/flab/cafeguidebook/enumeration/MenuGroup.java
+++ b/src/main/java/com/flab/cafeguidebook/enumeration/MenuGroup.java
@@ -1,5 +1,27 @@
 package com.flab.cafeguidebook.enumeration;
 
+import com.flab.cafeguidebook.enumeration.handler.MenuGroupTypeHandler;
+import org.apache.ibatis.type.MappedTypes;
+
 public enum MenuGroup {
-  DRINK, DESSERT
+  DRINK(0), DESSERT(1);
+
+  private final int code;
+
+  MenuGroup(int code) {
+    this.code = code;
+  }
+
+  public int getCode() {
+    return code;
+  }
+
+  @MappedTypes(MenuGroup.class)
+  public static class TypeHandler extends MenuGroupTypeHandler {
+
+    public TypeHandler() {
+      super(MenuGroup.class);
+    }
+  }
+
 }

--- a/src/main/java/com/flab/cafeguidebook/enumeration/MenuStatus.java
+++ b/src/main/java/com/flab/cafeguidebook/enumeration/MenuStatus.java
@@ -1,5 +1,26 @@
 package com.flab.cafeguidebook.enumeration;
 
+import com.flab.cafeguidebook.enumeration.handler.MenuStatusTypeHandler;
+import org.apache.ibatis.type.MappedTypes;
+
 public enum MenuStatus {
-  SALE, HIDDEN, SOLDOUT
+  SALE(0), HIDDEN(1), SOLDOUT(2);
+
+  private final int code;
+
+  MenuStatus(int code) {
+    this.code = code;
+  }
+
+  public int getCode() {
+    return code;
+  }
+
+  @MappedTypes(MenuStatus.class)
+  public static class TypeHandler extends MenuStatusTypeHandler {
+
+    public TypeHandler() {
+      super(MenuStatus.class);
+    }
+  }
 }

--- a/src/main/java/com/flab/cafeguidebook/enumeration/OptionStatus.java
+++ b/src/main/java/com/flab/cafeguidebook/enumeration/OptionStatus.java
@@ -1,5 +1,26 @@
 package com.flab.cafeguidebook.enumeration;
 
+import com.flab.cafeguidebook.enumeration.handler.OptionStatusTypeHandler;
+import org.apache.ibatis.type.MappedTypes;
+
 public enum OptionStatus {
-  SALE, HIDDEN, SOLDOUT
+  SALE(0), HIDDEN(1), SOLDOUT(2);
+
+  private final int code;
+
+  OptionStatus(int code) {
+    this.code = code;
+  }
+
+  public int getCode() {
+    return code;
+  }
+
+  @MappedTypes(OptionStatus.class)
+  public static class TypeHandler extends OptionStatusTypeHandler {
+
+    public TypeHandler() {
+      super(OptionStatus.class);
+    }
+  }
 }

--- a/src/main/java/com/flab/cafeguidebook/enumeration/handler/CafeConditionTypeHandler.java
+++ b/src/main/java/com/flab/cafeguidebook/enumeration/handler/CafeConditionTypeHandler.java
@@ -1,0 +1,61 @@
+package com.flab.cafeguidebook.enumeration.handler;
+
+import com.flab.cafeguidebook.enumeration.CafeCondition;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.TypeException;
+import org.apache.ibatis.type.TypeHandler;
+
+public class CafeConditionTypeHandler implements TypeHandler<CafeCondition> {
+
+  private Class<CafeCondition> type;
+
+  public CafeConditionTypeHandler(Class<CafeCondition> type) {
+    this.type = type;
+  }
+
+  @Override
+  public void setParameter(PreparedStatement ps, int i, CafeCondition parameter, JdbcType jdbcType)
+      throws SQLException {
+    if (parameter == null) {
+      ps.setNull(i, jdbcType.TYPE_CODE);
+    } else {
+      ps.setInt(i, parameter.getCode());
+    }
+  }
+
+  @Override
+  public CafeCondition getResult(ResultSet rs, String columnName) throws SQLException {
+    int code = rs.getInt(columnName);
+    return getCafeCondition(code);
+  }
+
+  @Override
+  public CafeCondition getResult(ResultSet rs, int columnIndex) throws SQLException {
+    int code = rs.getInt(columnIndex);
+    return getCafeCondition(code);
+  }
+
+  @Override
+  public CafeCondition getResult(CallableStatement cs, int columnIndex) throws SQLException {
+    int code = cs.getInt(columnIndex);
+    return getCafeCondition(code);
+  }
+
+  private CafeCondition getCafeCondition(int code) {
+    try {
+      CafeCondition[] enumConstants = (CafeCondition[]) type.getEnumConstants();
+      for (CafeCondition cafeCondition : enumConstants) {
+        if (cafeCondition.getCode() == code) {
+          return cafeCondition;
+        }
+      }
+      return null;
+    } catch (Exception e) {
+      throw new TypeException("Can't make enum object '" + type + "'", e);
+    }
+  }
+}

--- a/src/main/java/com/flab/cafeguidebook/enumeration/handler/CafeRegistrationTypeHandler.java
+++ b/src/main/java/com/flab/cafeguidebook/enumeration/handler/CafeRegistrationTypeHandler.java
@@ -17,42 +17,46 @@ public class CafeRegistrationTypeHandler implements TypeHandler<CafeRegistration
     this.type = type;
   }
 
-  public void setParameter(PreparedStatement preparedStatement, int i, CafeRegistration type,
-      JdbcType jdbcType) throws
-      SQLException {
-    preparedStatement.setInt(i, type.getCode());
+  @Override
+  public void setParameter(PreparedStatement ps, int i, CafeRegistration parameter,
+      JdbcType jdbcType) throws SQLException {
+    if (parameter == null) {
+      ps.setNull(i, jdbcType.TYPE_CODE);
+    } else {
+      ps.setInt(i, parameter.getCode());
+    }
   }
 
   @Override
-  public CafeRegistration getResult(ResultSet resultSet, String s) throws SQLException {
-    int statusCode = resultSet.getInt(s);
-    return getStatus(statusCode);
+  public CafeRegistration getResult(ResultSet rs, String columnName) throws SQLException {
+    int code = rs.getInt(columnName);
+    return getCafeRegistration(code);
   }
 
   @Override
-  public CafeRegistration getResult(ResultSet resultSet, int i) throws SQLException {
-    int statusCode = resultSet.getInt(i);
-    return getStatus(statusCode);
+  public CafeRegistration getResult(ResultSet rs, int columnIndex) throws SQLException {
+    int code = rs.getInt(columnIndex);
+    return getCafeRegistration(code);
   }
 
   @Override
-  public CafeRegistration getResult(CallableStatement callableStatement, int i)
-      throws SQLException {
-    int statusCode = callableStatement.getInt(i);
-    return getStatus(statusCode);
+  public CafeRegistration getResult(CallableStatement cs, int columnIndex) throws SQLException {
+    int code = cs.getInt(columnIndex);
+    return getCafeRegistration(code);
   }
 
-  private CafeRegistration getStatus(int statusCode) {
+  private CafeRegistration getCafeRegistration(int code) {
     try {
       CafeRegistration[] enumConstants = (CafeRegistration[]) type.getEnumConstants();
-      for (CafeRegistration status : enumConstants) {
-        if (status.getCode() == statusCode) {
-          return status;
+      for (CafeRegistration cafeRegistration : enumConstants) {
+        if (cafeRegistration.getCode() == code) {
+          return cafeRegistration;
         }
       }
       return null;
-    } catch (Exception exception) {
-      throw new TypeException("Can't make enum object '" + type + "'", exception);
+    } catch (Exception e) {
+      throw new TypeException("Can't make enum object '" + type + "'", e);
     }
   }
 }
+

--- a/src/main/java/com/flab/cafeguidebook/enumeration/handler/MenuGroupTypeHandler.java
+++ b/src/main/java/com/flab/cafeguidebook/enumeration/handler/MenuGroupTypeHandler.java
@@ -1,0 +1,61 @@
+package com.flab.cafeguidebook.enumeration.handler;
+
+import com.flab.cafeguidebook.enumeration.MenuGroup;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.TypeException;
+import org.apache.ibatis.type.TypeHandler;
+
+public class MenuGroupTypeHandler implements TypeHandler<MenuGroup> {
+
+  private Class<MenuGroup> type;
+
+  public MenuGroupTypeHandler(Class<MenuGroup> type) {
+    this.type = type;
+  }
+
+  @Override
+  public void setParameter(PreparedStatement ps, int i, MenuGroup parameter, JdbcType jdbcType)
+      throws SQLException {
+    if (parameter == null) {
+      ps.setNull(i, jdbcType.TYPE_CODE);
+    } else {
+      ps.setInt(i, parameter.getCode());
+    }
+  }
+
+  @Override
+  public MenuGroup getResult(ResultSet rs, String columnName) throws SQLException {
+    int code = rs.getInt(columnName);
+    return getMenuGroup(code);
+  }
+
+  @Override
+  public MenuGroup getResult(ResultSet rs, int columnIndex) throws SQLException {
+    int code = rs.getInt(columnIndex);
+    return getMenuGroup(code);
+  }
+
+  @Override
+  public MenuGroup getResult(CallableStatement cs, int columnIndex) throws SQLException {
+    int code = cs.getInt(columnIndex);
+    return getMenuGroup(code);
+  }
+
+  private MenuGroup getMenuGroup(int code) {
+    try {
+      MenuGroup[] enumConstants = (MenuGroup[]) type.getEnumConstants();
+      for (MenuGroup menuGroup : enumConstants) {
+        if (menuGroup.getCode() == code) {
+          return menuGroup;
+        }
+      }
+      return null;
+    } catch (Exception e) {
+      throw new TypeException("Can't make enum object '" + type + "'", e);
+    }
+  }
+}

--- a/src/main/java/com/flab/cafeguidebook/enumeration/handler/MenuStatusTypeHandler.java
+++ b/src/main/java/com/flab/cafeguidebook/enumeration/handler/MenuStatusTypeHandler.java
@@ -1,0 +1,61 @@
+package com.flab.cafeguidebook.enumeration.handler;
+
+import com.flab.cafeguidebook.enumeration.MenuStatus;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.TypeException;
+import org.apache.ibatis.type.TypeHandler;
+
+public class MenuStatusTypeHandler implements TypeHandler<MenuStatus> {
+
+  private Class<MenuStatus> type;
+
+  public MenuStatusTypeHandler(Class<MenuStatus> type) {
+    this.type = type;
+  }
+
+  @Override
+  public void setParameter(PreparedStatement ps, int i, MenuStatus parameter, JdbcType jdbcType)
+      throws SQLException {
+    if (parameter == null) {
+      ps.setNull(i, jdbcType.TYPE_CODE);
+    } else {
+      ps.setInt(i, parameter.getCode());
+    }
+  }
+
+  @Override
+  public MenuStatus getResult(ResultSet rs, String columnName) throws SQLException {
+    int code = rs.getInt(columnName);
+    return getMenuStatus(code);
+  }
+
+  @Override
+  public MenuStatus getResult(ResultSet rs, int columnIndex) throws SQLException {
+    int code = rs.getInt(columnIndex);
+    return getMenuStatus(code);
+  }
+
+  @Override
+  public MenuStatus getResult(CallableStatement cs, int columnIndex) throws SQLException {
+    int code = cs.getInt(columnIndex);
+    return getMenuStatus(code);
+  }
+
+  private MenuStatus getMenuStatus(int code) {
+    try {
+      MenuStatus[] enumConstants = (MenuStatus[]) type.getEnumConstants();
+      for (MenuStatus menuStatus : enumConstants) {
+        if (menuStatus.getCode() == code) {
+          return menuStatus;
+        }
+      }
+      return null;
+    } catch (Exception e) {
+      throw new TypeException("Can't make enum object '" + type + "'", e);
+    }
+  }
+}

--- a/src/main/java/com/flab/cafeguidebook/enumeration/handler/OptionStatusTypeHandler.java
+++ b/src/main/java/com/flab/cafeguidebook/enumeration/handler/OptionStatusTypeHandler.java
@@ -1,0 +1,62 @@
+package com.flab.cafeguidebook.enumeration.handler;
+
+import com.flab.cafeguidebook.enumeration.OptionStatus;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.TypeException;
+import org.apache.ibatis.type.TypeHandler;
+
+public class OptionStatusTypeHandler implements TypeHandler<OptionStatus> {
+
+  private Class<OptionStatus> type;
+
+  public OptionStatusTypeHandler(Class<OptionStatus> type) {
+    this.type = type;
+  }
+
+  @Override
+  public void setParameter(PreparedStatement ps, int i, OptionStatus parameter, JdbcType jdbcType)
+      throws SQLException {
+    if (parameter == null) {
+      ps.setNull(i, jdbcType.TYPE_CODE);
+    } else {
+      ps.setInt(i, parameter.getCode());
+    }
+  }
+
+  @Override
+  public OptionStatus getResult(ResultSet rs, String columnName) throws SQLException {
+    int code = rs.getInt(columnName);
+    return getOptionStatus(code);
+  }
+
+  @Override
+  public OptionStatus getResult(ResultSet rs, int columnIndex) throws SQLException {
+    int code = rs.getInt(columnIndex);
+    return getOptionStatus(code);
+  }
+
+  @Override
+  public OptionStatus getResult(CallableStatement cs, int columnIndex) throws SQLException {
+    int code = cs.getInt(columnIndex);
+    return getOptionStatus(code);
+  }
+
+  private OptionStatus getOptionStatus(int code) {
+    try {
+      OptionStatus[] enumConstants = (OptionStatus[]) type.getEnumConstants();
+      for (OptionStatus optionStatus : enumConstants) {
+        if (optionStatus.getCode() == code) {
+          return optionStatus;
+        }
+      }
+      return null;
+    } catch (Exception e) {
+      throw new TypeException("Can't make enum object '" + type + "'", e);
+    }
+  }
+}

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -547,47 +547,20 @@ CI/CD와 클라우드 서비스를 이용해 직접 서버에 배포까지 해�
 <h4 id="_로그인">로그인</h4>
 <div class="sect4">
 <h5 id="_request_parameters">Request Parameters</h5>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">이메일 (필수)</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">패스워드 (필수)</p></td>
-</tr>
-</tbody>
-</table>
+<div class="paragraph">
+<p>Unresolved directive in index.adoc - include::C:\Users\User\f-lab-project\cafe-guide-book\build\generated-snippets/sign-in/request-parameters.adoc[]</p>
+</div>
 </div>
 <div class="sect4">
 <h5 id="_http_request">HTTP Request</h5>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /users/signIn HTTP/1.1
-Content-Type: application/json
-Host: docs.api.com
-
-email=yssj2049%40gmail.com&amp;password=Cafe1234%21</code></pre>
-</div>
+<div class="paragraph">
+<p>Unresolved directive in index.adoc - include::C:\Users\User\f-lab-project\cafe-guide-book\build\generated-snippets/sign-in/http-request.adoc[]</p>
 </div>
 </div>
 <div class="sect4">
 <h5 id="_response_body">Response Body</h5>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs"></code></pre>
-</div>
+<div class="paragraph">
+<p>Unresolved directive in index.adoc - include::C:\Users\User\f-lab-project\cafe-guide-book\build\generated-snippets/sign-in/response-body.adoc[]</p>
 </div>
 </div>
 </div>
@@ -595,80 +568,20 @@ email=yssj2049%40gmail.com&amp;password=Cafe1234%21</code></pre>
 <h4 id="_회원가입">회원가입</h4>
 <div class="sect4">
 <h5 id="_request_fields">Request Fields</h5>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">이메일 (필수)</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>password</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">패스워드 (필수. 영문, 숫자, 특수문자를 반드시 포함 8~20자리)</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>name</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">이름 (필수)</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>phone</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">휴대폰 번호 (필수)</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>address</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">주소 (필수)</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>userType</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">유저타입 (필수, 일반회원 : 1, 카페사장님 : 2, 어드민 : 3)</p></td>
-</tr>
-</tbody>
-</table>
+<div class="paragraph">
+<p>Unresolved directive in index.adoc - include::C:\Users\User\f-lab-project\cafe-guide-book\build\generated-snippets/sign-up/request-fields.adoc[]</p>
+</div>
 </div>
 <div class="sect4">
 <h5 id="_http_request_2">HTTP Request</h5>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /users/signUp HTTP/1.1
-Content-Type: application/json
-Accept: application/json
-Content-Length: 190
-Host: docs.api.com
-
-{
-  "email" : "yssj2049@gmail.com",
-  "password" : "Cafe1234!",
-  "name" : "김민성",
-  "phone" : "010-8358-2049",
-  "address" : "경기도 화성시 호수공원",
-  "userType" : "USER"
-}</code></pre>
-</div>
+<div class="paragraph">
+<p>Unresolved directive in index.adoc - include::C:\Users\User\f-lab-project\cafe-guide-book\build\generated-snippets/sign-up/http-request.adoc[]</p>
 </div>
 </div>
 <div class="sect4">
 <h5 id="_response_body_2">Response Body</h5>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs"></code></pre>
-</div>
+<div class="paragraph">
+<p>Unresolved directive in index.adoc - include::C:\Users\User\f-lab-project\cafe-guide-book\build\generated-snippets/sign-up/response-body.adoc[]</p>
 </div>
 </div>
 </div>
@@ -676,50 +589,20 @@ Host: docs.api.com
 <h4 id="_유저정보_조회">유저정보 조회</h4>
 <div class="sect4">
 <h5 id="_path_parameters">Path Parameters</h5>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 1. /users/{email}</caption>
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">이메일</p></td>
-</tr>
-</tbody>
-</table>
+<div class="paragraph">
+<p>Unresolved directive in index.adoc - include::C:\Users\User\f-lab-project\cafe-guide-book\build\generated-snippets/get-user/path-parameters.adoc[]</p>
+</div>
 </div>
 <div class="sect4">
 <h5 id="_http_request_3">HTTP Request</h5>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /users/yssj2049@gmail.com HTTP/1.1
-Content-Type: application/json
-Accept: application/json
-Host: docs.api.com</code></pre>
-</div>
+<div class="paragraph">
+<p>Unresolved directive in index.adoc - include::C:\Users\User\f-lab-project\cafe-guide-book\build\generated-snippets/get-user/http-request.adoc[]</p>
 </div>
 </div>
 <div class="sect4">
 <h5 id="_response_body_3">Response Body</h5>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs">{
-  "email" : "yssj2049@gmail.com",
-  "password" : null,
-  "name" : "김민성",
-  "phone" : "010-8358-2049",
-  "address" : "경기도 화성시 호수공원",
-  "userType" : null
-}</code></pre>
-</div>
+<div class="paragraph">
+<p>Unresolved directive in index.adoc - include::C:\Users\User\f-lab-project\cafe-guide-book\build\generated-snippets/get-user/response-body.adoc[]</p>
 </div>
 </div>
 </div>
@@ -727,61 +610,14 @@ Host: docs.api.com</code></pre>
 <h4 id="_로그아웃">로그아웃</h4>
 <div class="sect4">
 <h5 id="_http_request_4">HTTP Request</h5>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /users/signOut HTTP/1.1
-Host: docs.api.com</code></pre>
-</div>
+<div class="paragraph">
+<p>Unresolved directive in index.adoc - include::C:\Users\User\f-lab-project\cafe-guide-book\build\generated-snippets/sign-out/http-request.adoc[]</p>
 </div>
 </div>
 <div class="sect4">
 <h5 id="_response_body_4">Response Body</h5>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs"></code></pre>
-</div>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_회원탈퇴">회원탈퇴</h4>
-<div class="sect4">
-<h5 id="_path_parameters_2">Path Parameters</h5>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 2. /users/withdrawal/{email}</caption>
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>email</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">회원탈퇴할 계정의 이메일</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect4">
-<h5 id="_http_request_5">HTTP Request</h5>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /users/withdrawal/yssj2049@gmail.com HTTP/1.1
-Host: docs.api.com</code></pre>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="_response_body_5">Response Body</h5>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-none hljs"></code></pre>
-</div>
+<div class="paragraph">
+<p>Unresolved directive in index.adoc - include::C:\Users\User\f-lab-project\cafe-guide-book\build\generated-snippets/sign-out/response-body.adoc[]</p>
 </div>
 </div>
 </div>
@@ -792,7 +628,7 @@ Host: docs.api.com</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2021-09-13 17:21:22 +0900
+Last updated 2021-09-11 21:48:52 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/java/com/flab/cafeguidebook/controller/MenuControllerTest.java
+++ b/src/test/java/com/flab/cafeguidebook/controller/MenuControllerTest.java
@@ -41,6 +41,9 @@ public class MenuControllerTest {
   @Test
   public void addMenu(MenuDTO testMenuDTO) throws Exception {
 
+    String menuGroupEnum = testMenuDTO.getMenuGroup() == null ? null : testMenuDTO.getMenuGroup().toString();
+    String menuStatusEnum = testMenuDTO.getMenuStatus() == null ? null : testMenuDTO.getMenuStatus().toString();
+
     mockMvc.perform(post("/owner/cafe/" + testMenuDTO.getCafeId() + "/menu")
         .contentType(MediaType.APPLICATION_JSON_UTF8)
         .content(objectMapper.writeValueAsString(testMenuDTO))
@@ -49,7 +52,9 @@ public class MenuControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("cafeId").value(testMenuDTO.getCafeId()))
         .andExpect(jsonPath("menuName").value(testMenuDTO.getMenuName()))
-        .andExpect(jsonPath("menuPrice").value(testMenuDTO.getMenuPrice()));
+        .andExpect(jsonPath("menuPrice").value(testMenuDTO.getMenuPrice()))
+        .andExpect(jsonPath("menuGroup").value(menuGroupEnum))
+        .andExpect(jsonPath("menuStatus").value(menuStatusEnum));
   }
 
   @Test
@@ -57,15 +62,18 @@ public class MenuControllerTest {
 
     final long CAFEID = 1;
 
+    String optionStatusEnum = testOptionDTO.getOptionStatus() == null ? null : testOptionDTO.getOptionStatus().toString();
+
     mockMvc.perform(post("/owner/cafe/" + CAFEID + "/menu/" + testOptionDTO.getMenuId() + "/options/")
-        .contentType(MediaType.APPLICATION_JSON_UTF8)
-        .content(objectMapper.writeValueAsString(testOptionDTO))
-        .accept(MediaType.APPLICATION_JSON_UTF8))
+            .contentType(MediaType.APPLICATION_JSON_UTF8)
+            .content(objectMapper.writeValueAsString(testOptionDTO))
+            .accept(MediaType.APPLICATION_JSON_UTF8))
         .andDo(print())
         .andExpect(status().isOk())
         .andExpect(jsonPath("optionName").value(testOptionDTO.getOptionName()))
         .andExpect(jsonPath("menuId").value(testOptionDTO.getMenuId()))
-        .andExpect(jsonPath("optionPrice").value(testOptionDTO.getOptionPrice()));
+        .andExpect(jsonPath("optionPrice").value(testOptionDTO.getOptionPrice()))
+        .andExpect(jsonPath("optionStatus").value(optionStatusEnum));
   }
 
   @Test
@@ -74,6 +82,9 @@ public class MenuControllerTest {
     final long MENUID = 1;
 
     testMenuDTO.setMenuId(MENUID);
+
+    String menuGroupEnum = testMenuDTO.getMenuGroup() == null ? null : testMenuDTO.getMenuGroup().toString();
+    String menuStatusEnum = testMenuDTO.getMenuStatus() == null ? null : testMenuDTO.getMenuStatus().toString();
 
     mockMvc.perform(post("/owner/cafe/" + testMenuDTO.getCafeId() + "/menu/" + testMenuDTO.getMenuId())
         .contentType(MediaType.APPLICATION_JSON_UTF8)
@@ -84,7 +95,9 @@ public class MenuControllerTest {
         .andExpect(jsonPath("menuId").value(testMenuDTO.getMenuId()))
         .andExpect(jsonPath("cafeId").value(testMenuDTO.getCafeId()))
         .andExpect(jsonPath("menuName").value(testMenuDTO.getMenuName()))
-        .andExpect(jsonPath("menuPrice").value(testMenuDTO.getMenuPrice()));
+        .andExpect(jsonPath("menuPrice").value(testMenuDTO.getMenuPrice()))
+        .andExpect(jsonPath("menuGroup").value(menuGroupEnum))
+        .andExpect(jsonPath("menuStatus").value(menuStatusEnum));
   }
 
   @Test
@@ -99,7 +112,10 @@ public class MenuControllerTest {
     testOptionDTO.setMenuId(MENUID);
     testOptionDTO.setOptionId(OPTIONID);
 
-    mockMvc.perform(post("/owner/cafe/" + CAFEID + "/menu/" + testOptionDTO.getMenuId() + "/options/" + testOptionDTO.getOptionId())
+    String optionStatusEnum = testOptionDTO.getOptionStatus() == null ? null : testOptionDTO.getOptionStatus().toString();
+
+    mockMvc.perform(post("/owner/cafe/" + CAFEID + "/menu/" + testOptionDTO.getMenuId() + "/options/" + testOptionDTO
+            .getOptionId())
         .contentType(MediaType.APPLICATION_JSON_UTF8)
         .content(objectMapper.writeValueAsString(testOptionDTO))
         .accept(MediaType.APPLICATION_JSON_UTF8))
@@ -108,7 +124,6 @@ public class MenuControllerTest {
         .andExpect(jsonPath("optionId").value(testOptionDTO.getOptionId()))
         .andExpect(jsonPath("optionName").value(testOptionDTO.getOptionName()))
         .andExpect(jsonPath("optionPrice").value(testOptionDTO.getOptionPrice()))
-        .andExpect(jsonPath("optionStatus").value(testOptionDTO.getOptionStatus()));
-
+        .andExpect(jsonPath("optionStatus").value(optionStatusEnum));
   }
 }

--- a/src/test/java/com/flab/cafeguidebook/fixture/MenuFixtureProvider.java
+++ b/src/test/java/com/flab/cafeguidebook/fixture/MenuFixtureProvider.java
@@ -1,6 +1,8 @@
 package com.flab.cafeguidebook.fixture;
 
 import com.flab.cafeguidebook.domain.Menu;
+import com.flab.cafeguidebook.enumeration.MenuGroup;
+import com.flab.cafeguidebook.enumeration.MenuStatus;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
@@ -22,6 +24,8 @@ public class MenuFixtureProvider implements ParameterResolver {
         .menuName("아메리카노")
         .menuPrice(3000)
         .menuPriority(1)
+        .menuGroup(MenuGroup.DRINK)
+        .menuStatus(MenuStatus.SALE)
         .build();
   }
 }

--- a/src/test/java/com/flab/cafeguidebook/service/CafeServiceTest.java
+++ b/src/test/java/com/flab/cafeguidebook/service/CafeServiceTest.java
@@ -47,3 +47,4 @@ public class CafeServiceTest {
     assertThat(cafeService.denyRegistration(33333L)).isEqualTo(true);
   }
 }
+


### PR DESCRIPTION
Fixes #86 

## 개요

- mybatis에서 enum 타입 데이터를 바인딩하지 못하는 문제가 있습니다. 따라서 MyBatis 환경에서 Enum, Int 상호 변환을 자동으로 핸들링 해주는 TypeHandler를 적용합니다. 따라서 DB에 데이터를 저장하고 관리할 때 코드성 데이터로 관리할 수 있게 됩니다.

## 작업사항

- [x] 1.  Enum 타입 수정
- [x] 2. TypeHandler 구현 및 SqlSessionFactory에 추가
- [x] 3. 테스트 코드 수정 후 적용되는 지 확인



