### PR TITLE
[#105] Cafe 도메인 클래스 필요없는 nonnull 제거

### DIFF
--- a/src/main/java/com/flab/cafeguidebook/domain/Cafe.java
+++ b/src/main/java/com/flab/cafeguidebook/domain/Cafe.java
@@ -270,12 +270,12 @@ public class Cafe {
       return this;
     }
 
-    public Cafe.Builder userId(@NonNull final Long userId) {
+    public Cafe.Builder userId(final Long userId) {
       this.userId = userId;
       return this;
     }
 
-    public Cafe.Builder cafeId(@NonNull final Long cafeId) {
+    public Cafe.Builder cafeId(final Long cafeId) {
       this.cafeId = cafeId;
       return this;
     }


### PR DESCRIPTION
Fixes #105 

## 개요

- Cafe 도메인 클래스 non-null 제거

## 작업사항

- [x] 1. Cafe 도메인 클래스 non-null 제거