### PR TITLE
[#113] MenuMapper 테이블 이름 버그 수정

### DIFF
--- a/src/main/resources/mybatis/mapper/MenuMapper.xml
+++ b/src/main/resources/mybatis/mapper/MenuMapper.xml
@@ -18,7 +18,7 @@
     #{menuPrice},
     #{menuPhoto},
     (select max(menu_priority) + 1 as priority
-    from (select menu_priority from menu WHERE cafe_id = 1) all_menu),
+    from (select menu_priority from MENU WHERE cafe_id = 1) all_menu),
     #{menuInfo},
     now(),
     now(),


### PR DESCRIPTION
Fixes #113 

## 개요

- 젠킨스에서 테스트 코드가 실행될 때 MenuMapper 테이블 이름으로 인한 버그가 발생합니다.

## 작업사항

- [x] 1. MenuMapper에서 테이블 이름을 menu -> MENU로 수정합니다.
