### PR TITLE
[#105] fix : CafeMapper 테이블 명 수정

### DIFF
--- a/src/main/resources/mybatis/mapper/CafeMapper.xml
+++ b/src/main/resources/mybatis/mapper/CafeMapper.xml
@@ -44,14 +44,14 @@
   <select id="selectMyAllCafe" parameterType="long"
     resultType="com.flab.cafeguidebook.dto.CafeDTO">
     SELECT *
-    FROM cafe
+    FROM CAFE
     WHERE user_id = #{userId}
   </select>
 
   <select id="selectMyCafe" resultType="com.flab.cafeguidebook.dto.CafeDTO"
     parameterType="map">
     SELECT *
-    FROM cafe
+    FROM CAFE
     WHERE cafe_id = #{cafeId}
       AND user_id = #{userId}
   </select>
@@ -62,7 +62,7 @@
   </delete>
 
   <update id="updateCafe" parameterType="com.flab.cafeguidebook.dto.CafeDTO">
-    UPDATE cafe
+    UPDATE CAFE
     SET
     <if test="cafeName != null">cafe_name = #{cafeName},</if>
     <if test="tel != null">tel = #{tel},</if>

--- a/src/test/java/com/flab/cafeguidebook/controller/CafeControllerTest.java
+++ b/src/test/java/com/flab/cafeguidebook/controller/CafeControllerTest.java
@@ -68,7 +68,6 @@ public class CafeControllerTest {
   }
 
   @Test
-  @Disabled
   public void getMyAllCafe(List<CafeDTO> testCafeDTOList) throws Exception {
     for (int i = 0; i < testCafeDTOList.size(); i++) {
       addCafe(testCafeDTOList.get(i));
@@ -84,7 +83,6 @@ public class CafeControllerTest {
   }
 
   @Test
-  @Disabled
   public void updateCafe(CafeDTO testCafeDTO) throws Exception {
 
     final long CAFEID = 1;


### PR DESCRIPTION
Fixes #117 

## 개요

- 젠킨스 에러 로그를 보니 테이블명을 찾지 못해 에러가 발생합니다. 따라서 cafe -> CAFE로 테이블 이름을 변경합니다.

## 작업사항

- [x] 1. CafeMapper에서 cafe -> CAFE로 테이블 이름 변경