### PR TITLE
[#127] build.gradle에 multi-release attribute 추가

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -2,14 +2,14 @@ version: 0.0
 os: linux
 files:
   - source: /
-    destination: /home/ec2-user/cafeguidebook/
+    destination: /home/ec2-user/cafeguidebook
 file_exists_behavior: OVERWRITE
 permissions:
-  - object: /home/ec2-user/cafeguidebook/
+  - object: /home/ec2-user/cafeguidebook
     pattern: "*"
     owner: ec2-user
     group: ec2-user
-    mode: 755
+    mode: 775
     type:
       - directory
 hooks:

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ jar {
 
     manifest {
         attributes 'Main-Class': 'com.flab.cafeguidebook.CafeguidebookApplication'
+        attributes 'Multi-Release': 'true'
     }
     from {
         configurations.compileClasspath.collect {

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -17,4 +17,4 @@ else
 fi
 
 
-nohup $JAVA_HOME/bin/java -jar $JAR_NAME --spring.profiles.active=release > /dev/null 2>&1 &
+nohup java -jar $JAR_NAME --spring.profiles.active=release > /dev/null 2>&1 &


### PR DESCRIPTION
Fixes #127 

## 개요

- 애플리케이션을 시작할 때 Log4j2에서 에러가 발생합니다. 따라서 Manifest에 attributes 'Multi-Release': 'true'를 추가합니다.

## 작업사항

- [x] 1. Manifest에 attributes 'Multi-Release': 'true'를 추가