### PR TITLE
[#128] jar -> bootjar로 build.gradle 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,24 +59,11 @@ asciidoctor {
     dependsOn test
 }
 
-jar {
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 
+bootJar {
     dependsOn asciidoctor
     copy {
         from "${asciidoctor.outputDir}"
         into 'src/main/resources/static/docs'
     }
-
-    manifest {
-        attributes 'Main-Class': 'com.flab.cafeguidebook.CafeguidebookApplication'
-        attributes 'Multi-Release': 'true'
-    }
-    from {
-        configurations.compileClasspath.collect {
-            it.isDirectory() ? it : zipTree(it)
-        }
-    }
-
-    exclude "**/Log4j2Plugins.dat"
 }


### PR DESCRIPTION
Fixes #128 

## 개요

- jar로 빌드하면 필요한 dependency가 추가되지 않는 문제점이 있습니다. 따라서 Jar Task가 아닌 BootJar로 실행 가능한 Jar 파일을 만들어야 합니다.

## 작업사항

- [x] 1. Jar -> BootJar로 변경