### PR TITLE
[#140] Redis 관련 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ ext {
     springRestDocsMockMvcVersion = "2.0.5.RELEASE"
     snippetsDir = file('build/generated-snippets')
     springBootStarterAopVersion = "2.5.4"
+    springDataRedisVersion = "2.5.5"
+    lettuceCoreVersion = "6.1.5.RELEASE"
 }
 
 group = 'com.flab'
@@ -42,10 +44,13 @@ dependencies {
     implementation "com.google.guava:guava:$springGuavaVersion"
     implementation "org.mockito:mockito-core:$springMokitoVersion"
     implementation "com.zaxxer:HikariCP:$springHikariCPVersion"
+    implementation 'org.projectlombok:lombok:1.18.18'
     testImplementation "org.springframework.boot:spring-boot-starter-test:$springBootVersion"
     testImplementation "org.springframework.restdocs:spring-restdocs-mockmvc:$springRestDocsMockMvcVersion"
     asciidoctorExtensions "org.springframework.restdocs:spring-restdocs-asciidoctor:$springRestDocsMockMvcVersion"
     implementation "org.springframework.boot:spring-boot-starter-aop:$springBootStarterAopVersion"
+    implementation group: 'org.springframework.data', name: 'spring-data-redis', version: "$springDataRedisVersion"
+    implementation group: 'io.lettuce', name: 'lettuce-core', version: "$lettuceCoreVersion"
 }
 
 test {

--- a/src/main/java/com/flab/cafeguidebook/CafeguidebookApplication.java
+++ b/src/main/java/com/flab/cafeguidebook/CafeguidebookApplication.java
@@ -2,8 +2,10 @@ package com.flab.cafeguidebook;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class CafeguidebookApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/flab/cafeguidebook/config/RedisConfig.java
+++ b/src/main/java/com/flab/cafeguidebook/config/RedisConfig.java
@@ -1,0 +1,74 @@
+package com.flab.cafeguidebook.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.redis.host}")
+  private String redisHost;
+
+  @Value("${spring.redis.port}")
+  private int redisPort;
+
+  @Value("${spring.redis.password}")
+  private String redisPassword;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+
+    RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+    redisStandaloneConfiguration.setHostName(redisHost);
+    redisStandaloneConfiguration.setPort(redisPort);
+    redisStandaloneConfiguration.setPassword(redisPassword);
+    LettuceConnectionFactory lettuceConnectionFactory = new LettuceConnectionFactory(
+        redisStandaloneConfiguration);
+
+    return lettuceConnectionFactory;
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate() {
+
+    GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer =
+        new GenericJackson2JsonRedisSerializer();
+
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(genericJackson2JsonRedisSerializer);
+
+    return redisTemplate;
+  }
+
+  @Bean
+  public RedisCacheManager redisCacheManager() {
+
+    RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
+        .defaultCacheConfig()
+        .disableCachingNullValues()
+        .serializeKeysWith(
+            RedisSerializationContext.SerializationPair
+                .fromSerializer(new StringRedisSerializer()))
+        .serializeValuesWith(
+            RedisSerializationContext.SerializationPair
+                .fromSerializer(new GenericJackson2JsonRedisSerializer())
+        );
+
+    return RedisCacheManager.RedisCacheManagerBuilder
+        .fromConnectionFactory(redisConnectionFactory())
+        .cacheDefaults(redisCacheConfiguration).build();
+  }
+}


### PR DESCRIPTION
Fixes #140 

## 개요

- nGrinder로 부하 테스트 후 성능 개선을 위해 Redis 관련 설정들을 추가합니다.

## 작업사항

- [x] 1. `Gradle`에 관련 의존성 추가
- [x] 2. `redisConnectionFactory`, `redisTemplate`, `redisCacheManager`를 `Bean`으로 등록



