### PR TITLE
[#139] 장바구니에 카페의 메뉴를 추가할 수 있는 기능 구현

### DIFF
--- a/src/main/java/com/flab/cafeguidebook/config/RedisConfig.java
+++ b/src/main/java/com/flab/cafeguidebook/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.flab.cafeguidebook.config;
 
+import com.flab.cafeguidebook.domain.CartItem;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,6 +26,9 @@ public class RedisConfig {
   @Value("${spring.redis.password}")
   private String redisPassword;
 
+  @Value("${spring.redis.cart.port}")
+  private int redisCartPort;
+
   @Bean
   public RedisConnectionFactory redisConnectionFactory() {
 
@@ -45,6 +49,20 @@ public class RedisConfig {
         new GenericJackson2JsonRedisSerializer();
 
     RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(genericJackson2JsonRedisSerializer);
+
+    return redisTemplate;
+  }
+
+  @Bean
+  public RedisTemplate<String, CartItem> cartItemDTORedisTemplate() {
+    GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer =
+        new GenericJackson2JsonRedisSerializer();
+
+    RedisTemplate<String, CartItem> redisTemplate = new RedisTemplate<>();
 
     redisTemplate.setConnectionFactory(redisConnectionFactory());
     redisTemplate.setKeySerializer(new StringRedisSerializer());

--- a/src/main/java/com/flab/cafeguidebook/controller/CartController.java
+++ b/src/main/java/com/flab/cafeguidebook/controller/CartController.java
@@ -1,0 +1,27 @@
+package com.flab.cafeguidebook.controller;
+
+import com.flab.cafeguidebook.annotation.SignInCheck;
+import com.flab.cafeguidebook.dto.CartItemDTO;
+import com.flab.cafeguidebook.service.CartService;
+import com.flab.cafeguidebook.util.SessionKeys;
+import javax.servlet.http.HttpSession;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("users/{userId}/carts")
+public class CartController {
+
+  @Autowired
+  private CartService cartService;
+
+  @PostMapping
+  @SignInCheck
+  public void addCartItem(@RequestBody CartItemDTO cartItemDTO, HttpSession httpSession) {
+    Long userId = (Long) httpSession.getAttribute(SessionKeys.USER_ID);
+    cartService.addCartItem(userId, cartItemDTO);
+  }
+}

--- a/src/main/java/com/flab/cafeguidebook/dao/CartItemDAO.java
+++ b/src/main/java/com/flab/cafeguidebook/dao/CartItemDAO.java
@@ -1,0 +1,43 @@
+package com.flab.cafeguidebook.dao;
+
+import com.flab.cafeguidebook.domain.CartItem;
+import java.util.List;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class CartItemDAO {
+
+  private static final String cartKey = ":CART";
+  private final RedisTemplate<String, CartItem> redisTemplate;
+
+  public CartItemDAO(
+      RedisTemplate<String, CartItem> redisTemplate) {
+    this.redisTemplate = redisTemplate;
+  }
+
+  public static String generateCartKey(Long id) {
+    return id.toString() + cartKey;
+  }
+
+  public List<CartItem> selectCartList(Long userId) {
+
+    final String key = generateCartKey(userId);
+
+    List<CartItem> cartList = redisTemplate
+        .opsForList()
+        .range(key, 0, -1);
+
+    return cartList;
+  }
+
+  public void insertCartItem(Long userId, CartItem cart) {
+    final String key = generateCartKey(userId);
+    redisTemplate.opsForList().rightPush(key, cart);
+  }
+
+  public void deleteCartItemList(Long userId) {
+    final String key = generateCartKey(userId);
+    redisTemplate.delete(key);
+  }
+}

--- a/src/main/java/com/flab/cafeguidebook/domain/CartItem.java
+++ b/src/main/java/com/flab/cafeguidebook/domain/CartItem.java
@@ -1,0 +1,181 @@
+package com.flab.cafeguidebook.domain;
+
+import com.flab.cafeguidebook.dto.CartOptionDTO;
+import java.util.List;
+
+public class CartItem {
+
+  private Long id;
+
+  private String name;
+
+  private Long price;
+
+  private Long cafeId;
+
+  private Long menuId;
+
+  private Long count;
+
+  private Long userId;
+  private List<CartOptionDTO> optionList;
+
+  public CartItem(CartItem.Builder builder) {
+    this.id = builder.id;
+    this.name = builder.name;
+    this.price = builder.price;
+    this.cafeId = builder.cafeId;
+    this.menuId = builder.menuId;
+    this.count = builder.userId;
+    this.userId = builder.userId;
+    this.optionList = builder.optionList;
+  }
+
+  public CartItem(Long id, String name, Long price, Long cafeId, Long menuId, Long count,
+      Long userId, List<CartOptionDTO> optionList) {
+    this.id = id;
+    this.name = name;
+    this.price = price;
+    this.cafeId = cafeId;
+    this.menuId = menuId;
+    this.count = count;
+    this.userId = userId;
+    this.optionList = optionList;
+  }
+
+  public static CartItem.Builder builder() {
+    return new CartItem.Builder();
+  }
+
+  public Long getMenuId() {
+    return menuId;
+  }
+
+  public void setMenuId(Long menuId) {
+    this.menuId = menuId;
+  }
+
+  public Long getCount() {
+    return count;
+  }
+
+  public void setCount(Long count) {
+    this.count = count;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public void setUserId(Long userId) {
+    this.userId = userId;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Long getPrice() {
+    return price;
+  }
+
+  public void setPrice(Long price) {
+    this.price = price;
+  }
+
+  public Long getCafeId() {
+    return cafeId;
+  }
+
+  public void setCafeId(Long cafeId) {
+    this.cafeId = cafeId;
+  }
+
+  public List<CartOptionDTO> getOptionList() {
+    return optionList;
+  }
+
+  public void setOptionList(List<CartOptionDTO> optionList) {
+    this.optionList = optionList;
+  }
+
+  public static class Builder {
+
+    private Long id;
+
+    private String name;
+
+    private Long price;
+
+    private Long cafeId;
+
+    private Long menuId;
+
+    private Long count;
+
+    private Long userId;
+
+    private List<CartOptionDTO> optionList;
+
+
+    public CartItem.Builder Builder() {
+      return this;
+    }
+
+    public CartItem.Builder id(Long id) {
+      this.id = id;
+      return this;
+    }
+
+    public CartItem.Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public CartItem.Builder price(Long price) {
+      this.price = price;
+      return this;
+    }
+
+    public CartItem.Builder cafeId(Long cafeId) {
+      this.cafeId = cafeId;
+      return this;
+    }
+
+    public CartItem.Builder menuId(Long menuId) {
+      this.menuId = menuId;
+      return this;
+    }
+
+    public CartItem.Builder count(Long count) {
+      this.count = count;
+      return this;
+    }
+
+    public CartItem.Builder userId(Long userId) {
+      this.userId = userId;
+      return this;
+    }
+
+    public CartItem.Builder optionList(List<CartOptionDTO> optionList) {
+      this.optionList = optionList;
+      return this;
+    }
+
+    public CartItem build() {
+      return new CartItem(this);
+    }
+  }
+}

--- a/src/main/java/com/flab/cafeguidebook/domain/CartOption.java
+++ b/src/main/java/com/flab/cafeguidebook/domain/CartOption.java
@@ -1,0 +1,40 @@
+package com.flab.cafeguidebook.domain;
+
+public class CartOption {
+
+  private Long id;
+
+  private String name;
+
+  private Long price;
+
+  public CartOption(Long id, String name, Long price) {
+    this.id = id;
+    this.name = name;
+    this.price = price;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Long getPrice() {
+    return price;
+  }
+
+  public void setPrice(Long price) {
+    this.price = price;
+  }
+}

--- a/src/main/java/com/flab/cafeguidebook/dto/CartItemDTO.java
+++ b/src/main/java/com/flab/cafeguidebook/dto/CartItemDTO.java
@@ -1,0 +1,182 @@
+package com.flab.cafeguidebook.dto;
+
+import java.util.List;
+
+public class CartItemDTO {
+
+  private Long id;
+
+  private String name;
+
+  private Long price;
+
+  private Long cafeId;
+
+  private Long menuId;
+
+  private Long count;
+
+  private Long userId;
+
+  private List<CartOptionDTO> optionList;
+
+  public CartItemDTO(CartItemDTO.Builder builder) {
+    this.id = builder.id;
+    this.name = builder.name;
+    this.price = builder.price;
+    this.cafeId = builder.cafeId;
+    this.menuId = builder.menuId;
+    this.count = builder.userId;
+    this.userId = builder.userId;
+    this.optionList = builder.optionList;
+  }
+
+  public CartItemDTO(Long id, String name, Long price, Long cafeId, Long menuId, Long count,
+      Long userId, List<CartOptionDTO> optionList) {
+    this.id = id;
+    this.name = name;
+    this.price = price;
+    this.cafeId = cafeId;
+    this.menuId = menuId;
+    this.count = count;
+    this.userId = userId;
+    this.optionList = optionList;
+  }
+
+  public static CartItemDTO.Builder builder() {
+    return new CartItemDTO.Builder();
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Long getPrice() {
+    return price;
+  }
+
+  public void setPrice(Long price) {
+    this.price = price;
+  }
+
+  public Long getCafeId() {
+    return cafeId;
+  }
+
+  public void setCafeId(Long cafeId) {
+    this.cafeId = cafeId;
+  }
+
+  public List<CartOptionDTO> getOptionList() {
+    return optionList;
+  }
+
+  public void setOptionList(List<CartOptionDTO> optionList) {
+    this.optionList = optionList;
+  }
+
+  public Long getUserId() {
+    return userId;
+  }
+
+  public void setUserId(Long userId) {
+    this.userId = userId;
+  }
+
+  public Long getMenuId() {
+    return menuId;
+  }
+
+  public void setMenuId(Long menuId) {
+    this.menuId = menuId;
+  }
+
+  public Long getCount() {
+    return count;
+  }
+
+  public void setCount(Long count) {
+    this.count = count;
+  }
+
+  public static class Builder {
+
+    private Long id;
+
+    private String name;
+
+    private Long price;
+
+    private Long cafeId;
+
+    private Long menuId;
+
+    private Long count;
+
+    private Long userId;
+
+    private List<CartOptionDTO> optionList;
+
+
+    public CartItemDTO.Builder Builder() {
+      return this;
+    }
+
+    public CartItemDTO.Builder id(Long id) {
+      this.id = id;
+      return this;
+    }
+
+    public CartItemDTO.Builder name(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public CartItemDTO.Builder price(Long price) {
+      this.price = price;
+      return this;
+    }
+
+    public CartItemDTO.Builder cafeId(Long cafeId) {
+      this.cafeId = cafeId;
+      return this;
+    }
+
+    public CartItemDTO.Builder menuId(Long menuId) {
+      this.menuId = menuId;
+      return this;
+    }
+
+    public CartItemDTO.Builder count(Long count) {
+      this.count = count;
+      return this;
+    }
+
+    public CartItemDTO.Builder userId(Long userId) {
+      this.userId = userId;
+      return this;
+    }
+
+    public CartItemDTO.Builder optionList(List<CartOptionDTO> optionList) {
+      this.optionList = optionList;
+      return this;
+    }
+
+    public CartItemDTO build() {
+      return new CartItemDTO(this);
+    }
+  }
+
+}

--- a/src/main/java/com/flab/cafeguidebook/dto/CartOptionDTO.java
+++ b/src/main/java/com/flab/cafeguidebook/dto/CartOptionDTO.java
@@ -1,0 +1,40 @@
+package com.flab.cafeguidebook.dto;
+
+public class CartOptionDTO {
+
+  private Long id;
+
+  private String name;
+
+  private Long price;
+
+  public CartOptionDTO(Long id, String name, Long price) {
+    this.id = id;
+    this.name = name;
+    this.price = price;
+  }
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Long getPrice() {
+    return price;
+  }
+
+  public void setPrice(Long price) {
+    this.price = price;
+  }
+}

--- a/src/main/java/com/flab/cafeguidebook/service/CartService.java
+++ b/src/main/java/com/flab/cafeguidebook/service/CartService.java
@@ -1,0 +1,27 @@
+package com.flab.cafeguidebook.service;
+
+import com.flab.cafeguidebook.dao.CartItemDAO;
+import com.flab.cafeguidebook.domain.CartItem;
+import com.flab.cafeguidebook.dto.CartItemDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CartService {
+
+  @Autowired
+  private CartItemDAO cartItemDAO;
+
+  public void addCartItem(Long userId, CartItemDTO cartItemDTO) {
+    CartItem cartItem = CartItem.builder()
+        .id(cartItemDTO.getId())
+        .name(cartItemDTO.getName())
+        .price(cartItemDTO.getId())
+        .cafeId(cartItemDTO.getCafeId())
+        .menuId(cartItemDTO.getMenuId())
+        .count(cartItemDTO.getCount())
+        .build();
+
+    cartItemDAO.insertCartItem(userId, cartItem);
+  }
+}

--- a/src/test/java/com/flab/cafeguidebook/controller/CartControllerTest.java
+++ b/src/test/java/com/flab/cafeguidebook/controller/CartControllerTest.java
@@ -1,0 +1,50 @@
+package com.flab.cafeguidebook.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.cafeguidebook.dto.CartItemDTO;
+import com.flab.cafeguidebook.fixture.CartItemDTOFixtureProvider;
+import com.flab.cafeguidebook.util.SessionKeys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ExtendWith({SpringExtension.class, CartItemDTOFixtureProvider.class})
+@SpringBootTest
+public class CartControllerTest {
+
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Autowired
+  private WebApplicationContext webApplicationContext;
+
+  @BeforeEach
+  public void init() {
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+  }
+
+  @Test
+  public void addCartItem(CartItemDTO cartItemDTO) throws Exception {
+
+    mockMvc.perform(post("/users/" + cartItemDTO + "/carts")
+        .sessionAttr(SessionKeys.USER_ID, cartItemDTO.getUserId())
+        .contentType(MediaType.APPLICATION_JSON_UTF8)
+        .content(objectMapper.writeValueAsString(cartItemDTO))
+        .accept(MediaType.APPLICATION_JSON_UTF8))
+        .andDo(print())
+        .andExpect(status().isOk());
+  }
+}

--- a/src/test/java/com/flab/cafeguidebook/fixture/CartItemDTOFixtureProvider.java
+++ b/src/test/java/com/flab/cafeguidebook/fixture/CartItemDTOFixtureProvider.java
@@ -1,0 +1,30 @@
+package com.flab.cafeguidebook.fixture;
+
+import com.flab.cafeguidebook.dto.CartItemDTO;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+public class CartItemDTOFixtureProvider implements ParameterResolver {
+
+  @Override
+  public boolean supportsParameter(ParameterContext parameterContext,
+      ExtensionContext extensionContext) throws ParameterResolutionException {
+    return (parameterContext.getParameter().getType() == CartItemDTO.class);
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext parameterContext,
+      ExtensionContext extensionContext) throws ParameterResolutionException {
+    return CartItemDTO.builder()
+        .id(38L)
+        .name("아이스 아메리카노")
+        .price(4000L)
+        .cafeId(255233324L)
+        .menuId(4535L)
+        .count(8732L)
+        .userId(3332L)
+        .build();
+  }
+}

--- a/src/test/java/com/flab/cafeguidebook/fixture/CartItemFixtureProvider.java
+++ b/src/test/java/com/flab/cafeguidebook/fixture/CartItemFixtureProvider.java
@@ -1,0 +1,30 @@
+package com.flab.cafeguidebook.fixture;
+
+import com.flab.cafeguidebook.domain.CartItem;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+public class CartItemFixtureProvider implements ParameterResolver {
+
+  @Override
+  public boolean supportsParameter(ParameterContext parameterContext,
+      ExtensionContext extensionContext) throws ParameterResolutionException {
+    return (parameterContext.getParameter().getType() == CartItem.class);
+  }
+
+  @Override
+  public Object resolveParameter(ParameterContext parameterContext,
+      ExtensionContext extensionContext) throws ParameterResolutionException {
+    return CartItem.builder()
+        .id(38L)
+        .name("아이스 아메리카노")
+        .price(4000L)
+        .cafeId(255233324L)
+        .menuId(4535L)
+        .count(8732L)
+        .userId(3332L)
+        .build();
+  }
+}


### PR DESCRIPTION
Fixes #139 

## 개요

- 장바구니에 카페의 메뉴를 추가할 수 있는 기능을 구현합니다.

## 작업사항

- [x] 1. `CartController` 구현
- [x] 2. `CartItem`, `CartOption`, `CartItemDTO`, `CartOptionDTO` 정의
- [x] 3. `FixtureProvider`구현
- [x] 4. `CartDAO` 구현



