### PR TITLE
[#144] MySQL Replication 적용

### DIFF
--- a/src/main/java/com/flab/cafeguidebook/annotation/DataSource.java
+++ b/src/main/java/com/flab/cafeguidebook/annotation/DataSource.java
@@ -1,0 +1,18 @@
+package com.flab.cafeguidebook.annotation;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface DataSource {
+
+  DataSourceType dataSourceType();
+
+  enum DataSourceType {
+    MASTER, SLAVE;
+  }
+}

--- a/src/main/java/com/flab/cafeguidebook/annotation/MasterDataSource.java
+++ b/src/main/java/com/flab/cafeguidebook/annotation/MasterDataSource.java
@@ -1,0 +1,14 @@
+package com.flab.cafeguidebook.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier(value = "masterDataSource")
+public @interface MasterDataSource {
+
+}

--- a/src/main/java/com/flab/cafeguidebook/annotation/SlaveDataSource.java
+++ b/src/main/java/com/flab/cafeguidebook/annotation/SlaveDataSource.java
@@ -1,0 +1,14 @@
+package com.flab.cafeguidebook.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier(value = "slaveDataSource")
+public @interface SlaveDataSource {
+
+}

--- a/src/main/java/com/flab/cafeguidebook/aop/DataSourceAspect.java
+++ b/src/main/java/com/flab/cafeguidebook/aop/DataSourceAspect.java
@@ -1,0 +1,24 @@
+package com.flab.cafeguidebook.aop;
+
+import com.flab.cafeguidebook.annotation.DataSource;
+import com.flab.cafeguidebook.annotation.DataSource.DataSourceType;
+import com.flab.cafeguidebook.datasource.RoutingDataSourceManager;
+import com.flab.cafeguidebook.exception.DataSourceException;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class DataSourceAspect {
+
+  @Before("@annotation(com.flab.cafeguidebook.annotation.DataSource) && @annotation(target)")
+  public void setDataSource(DataSource target) throws DataSourceException {
+    if (target.dataSourceType() == DataSourceType.MASTER
+        || target.dataSourceType() == DataSourceType.SLAVE) {
+      RoutingDataSourceManager.setCurrentDataSourceName(target.dataSourceType());
+    } else {
+      throw new DataSourceException("DataSource type is wrong");
+    }
+  }
+}

--- a/src/main/java/com/flab/cafeguidebook/datasource/RoutingDataSourceManager.java
+++ b/src/main/java/com/flab/cafeguidebook/datasource/RoutingDataSourceManager.java
@@ -1,0 +1,21 @@
+package com.flab.cafeguidebook.datasource;
+
+
+import com.flab.cafeguidebook.annotation.DataSource.DataSourceType;
+
+public class RoutingDataSourceManager {
+
+  private static final ThreadLocal<DataSourceType> currentDataSourceName = new ThreadLocal<>();
+
+  public static DataSourceType getCurrentDataSourceName() {
+    return currentDataSourceName.get();
+  }
+
+  public static void setCurrentDataSourceName(DataSourceType dataSourceType) {
+    currentDataSourceName.set(dataSourceType);
+  }
+
+  public static void removeCurrentDataSourceName() {
+    currentDataSourceName.remove();
+  }
+}

--- a/src/main/java/com/flab/cafeguidebook/exception/DataSourceException.java
+++ b/src/main/java/com/flab/cafeguidebook/exception/DataSourceException.java
@@ -1,0 +1,10 @@
+package com.flab.cafeguidebook.exception;
+
+import java.sql.SQLException;
+
+public class DataSourceException extends SQLException {
+
+  public DataSourceException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/flab/cafeguidebook/mapper/CafeMapper.java
+++ b/src/main/java/com/flab/cafeguidebook/mapper/CafeMapper.java
@@ -1,27 +1,36 @@
 package com.flab.cafeguidebook.mapper;
 
+import com.flab.cafeguidebook.annotation.DataSource;
+import com.flab.cafeguidebook.annotation.DataSource.DataSourceType;
 import com.flab.cafeguidebook.domain.Cafe;
 import com.flab.cafeguidebook.dto.CafeDTO;
-import java.util.List;
-import org.apache.ibatis.annotations.Param;
 import com.flab.cafeguidebook.enumeration.CafeRegistration;
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface CafeMapper {
 
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   public int insertCafe(Cafe cafe);
 
+  @DataSource(dataSourceType = DataSourceType.SLAVE)
   public List<CafeDTO> selectMyAllCafe(long userId);
 
+  @DataSource(dataSourceType = DataSourceType.SLAVE)
   public boolean isMyCafe(@Param("cafeId") long cafeId, @Param("userId") long userId);
 
+  @DataSource(dataSourceType = DataSourceType.SLAVE)
   public CafeDTO selectMyCafe(@Param("cafeId") long cafeId, @Param("userId") long userId);
 
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   public void deleteAllCafe();
 
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   public int updateCafe(Cafe cafe);
 
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   public int updateRegistration(@Param("id") Long id,
       @Param("registration") CafeRegistration registration);
 

--- a/src/main/java/com/flab/cafeguidebook/mapper/HeartMapper.java
+++ b/src/main/java/com/flab/cafeguidebook/mapper/HeartMapper.java
@@ -1,5 +1,7 @@
 package com.flab.cafeguidebook.mapper;
 
+import com.flab.cafeguidebook.annotation.DataSource;
+import com.flab.cafeguidebook.annotation.DataSource.DataSourceType;
 import com.flab.cafeguidebook.dto.HeartDTO;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
@@ -8,11 +10,15 @@ import org.apache.ibatis.annotations.Param;
 @Mapper
 public interface HeartMapper {
 
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   public int insertHeart(@Param("userId") Long userId, @Param("cafeId") Long cafeId);
 
+  @DataSource(dataSourceType = DataSourceType.SLAVE)
   public HeartDTO selectHeart(@Param("userId") Long userId, @Param("cafeId") Long cafeId);
 
+  @DataSource(dataSourceType = DataSourceType.SLAVE)
   public List<HeartDTO> selectUsersHearts(@Param("userId") Long userId);
 
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   public int deleteHeart(@Param("userId") Long userId, @Param("cafeId") Long cafeId);
 }

--- a/src/main/java/com/flab/cafeguidebook/mapper/MenuMapper.java
+++ b/src/main/java/com/flab/cafeguidebook/mapper/MenuMapper.java
@@ -1,12 +1,16 @@
 package com.flab.cafeguidebook.mapper;
 
+import com.flab.cafeguidebook.annotation.DataSource;
+import com.flab.cafeguidebook.annotation.DataSource.DataSourceType;
 import com.flab.cafeguidebook.domain.Menu;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface MenuMapper {
 
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   public int insertMenu(Menu menu);
 
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   public int updateMenu(Menu menu);
 }

--- a/src/main/java/com/flab/cafeguidebook/mapper/OptionMapper.java
+++ b/src/main/java/com/flab/cafeguidebook/mapper/OptionMapper.java
@@ -1,12 +1,16 @@
 package com.flab.cafeguidebook.mapper;
 
+import com.flab.cafeguidebook.annotation.DataSource;
+import com.flab.cafeguidebook.annotation.DataSource.DataSourceType;
 import com.flab.cafeguidebook.domain.Option;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface OptionMapper {
 
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   public int insertOption(Option optionDTO);
 
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   public int updateOption(Option optionDTO);
 }

--- a/src/main/java/com/flab/cafeguidebook/mapper/ReviewMapper.java
+++ b/src/main/java/com/flab/cafeguidebook/mapper/ReviewMapper.java
@@ -1,5 +1,7 @@
 package com.flab.cafeguidebook.mapper;
 
+import com.flab.cafeguidebook.annotation.DataSource;
+import com.flab.cafeguidebook.annotation.DataSource.DataSourceType;
 import com.flab.cafeguidebook.domain.Review;
 import com.flab.cafeguidebook.dto.ReviewDTO;
 import java.util.List;
@@ -9,17 +11,25 @@ import org.apache.ibatis.annotations.Param;
 @Mapper
 public interface ReviewMapper {
 
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   public int insertReview(@Param("cafeId") Long cafeId, @Param("review") Review review);
 
+  @DataSource(dataSourceType = DataSourceType.SLAVE)
   public List<ReviewDTO> selectReviews(Long userId);
 
+  @DataSource(dataSourceType = DataSourceType.SLAVE)
   public List<ReviewDTO> selectCafesReviews(@Param("cafeId") Long cafeId);
 
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   public int deleteReview(@Param("userId") Long userId, @Param("cafeId") Long cafeId);
 
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   public int updateReview(@Param("reviewId") Long reviewId, @Param("newContent") String newContent);
 
+  @DataSource(dataSourceType = DataSourceType.SLAVE)
   public Long selectReviewOwnerId(@Param("reviewId") Long reviewId);
+
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   public int deleteReview(@Param("reviewId") Long reviewId);
 }
 

--- a/src/main/java/com/flab/cafeguidebook/mapper/UserMapper.java
+++ b/src/main/java/com/flab/cafeguidebook/mapper/UserMapper.java
@@ -1,20 +1,28 @@
 package com.flab.cafeguidebook.mapper;
 
+import com.flab.cafeguidebook.annotation.DataSource;
+import com.flab.cafeguidebook.annotation.DataSource.DataSourceType;
 import com.flab.cafeguidebook.dto.UserDTO;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface UserMapper {
 
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   int insertUser(UserDTO userDTO);
 
+  @DataSource(dataSourceType = DataSourceType.SLAVE)
   UserDTO selectUserByEmail(String email);
 
+  @DataSource(dataSourceType = DataSourceType.SLAVE)
   UserDTO getUserInfo(String email);
 
+  @DataSource(dataSourceType = DataSourceType.SLAVE)
   UserDTO selectUserByEmailAndPassword(String email, String password);
 
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   int deleteUser(String email);
 
+  @DataSource(dataSourceType = DataSourceType.MASTER)
   int updatePassword(String email, String newPassword);
 }

--- a/src/main/resources/application-release.properties
+++ b/src/main/resources/application-release.properties
@@ -1,4 +1,8 @@
-spring.datasource.hikari.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.hikari.jdbc-url=jdbc:mysql://cafe-guide-book.cnsqlfwosrry.ap-northeast-2.rds.amazonaws.com:3306/cafe-guide-book?serverTimezone=UTC&characterEncoding=UTF-8
-spring.datasource.hikari.username=root
-spring.datasource.hikari.password=Cafe1234!
+spring.datasource.hikari.master.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.hikari.master.jdbc-url=jdbc:mysql://cafe-guide-book.cnsqlfwosrry.ap-northeast-2.rds.amazonaws.com:3306/cafe-guide-book?serverTimezone=UTC&characterEncoding=UTF-8
+spring.datasource.hikari.master.username=root
+spring.datasource.hikari.master.password=Cafe1234!
+spring.datasource.hikari.slave.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.hikari.slave.jdbc-url=jdbc:mysql://cafe-guide-book-slave2.cnsqlfwosrry.ap-northeast-2.rds.amazonaws.com:3306/cafe-guide-book?serverTimezone=UTC&characterEncoding=UTF-8
+spring.datasource.hikari.slave.username=root
+spring.datasource.hikari.slave.password=Cafe1234!


### PR DESCRIPTION
Fixes #144 

## 개요

- 대규모 트래픽이 발생했을 때를 대비하여 프로젝트에 MySQL Replication을 적용합니다.
- 구체적인 내용은 [기술블로그](https://blog.minseong.kim/spring-with-mysql-replication.html)에 정리하였습니다.

## 작업사항

- [x] 1.  `RoutingDataSourceManager` 정의
- [x] 2.  AOP를 통해 Annotation을 통해 `Mapper`에서 `DataSource`를 분기하기 위해 `DataSourceAspect` 정의
- [x] 3.  `DataSourceType`을 `Enum`으로 정의 (`MASTER`, `SLAVE`)
- [x] 4.  각 Mapper에 조회 관련된 부분은 `SLAVE` , 쓰기, 수정, 삭제 관련된 부분은 `MASTER`를 `DataSource`를 바라보도록 선언
- [x] 5. `Master`와 `Slave`를 분리해서 `Properties` 재정의


